### PR TITLE
Downgraded NLog.AirBrake to use .Net 2.0

### DIFF
--- a/build/NLog.AirBrake.nuspec
+++ b/build/NLog.AirBrake.nuspec
@@ -15,6 +15,7 @@
     <releaseNotes>
         * 0.1.0.0 - Initial release
         * 0.2.0.0 - Rebuilt for .NET 3.5
+        * 0.4.0.0 - Builds both Frameworks .NET 2.0 and .NET 4.0
     </releaseNotes>
     <copyright>East Point Systems 2012 and contributors</copyright>
     <tags>NLog log error notification AirBrake Errbit</tags>
@@ -25,7 +26,9 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="NLog.AirBrake.dll" target="lib\net35" />
-    <file src="NLog.AirBrake.xml" target="lib\net35" />
+    <file src="v2.0\NLog.AirBrake.dll" target="lib\net20" />
+    <file src="v2.0\NLog.AirBrake.xml" target="lib\net20" />
+    <file src="v4.0\NLog.AirBrake.dll" target="lib\net40" />
+    <file src="v4.0\NLog.AirBrake.xml" target="lib\net40" />
   </files>
 </package>

--- a/build/build.proj
+++ b/build/build.proj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
-    <BuildOutDir>$(MSBuildThisFileDirectory)\BuildArtifacts\</BuildOutDir>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v2.0</TargetFrameworkVersion>
+    <BuildOutDir>$(MSBuildThisFileDirectory)\BuildArtifacts\$(TargetFrameworkVersion)</BuildOutDir>
     <RunCodeAnalysis>Always</RunCodeAnalysis> <!-- Default based on project, Always or Never -->
     <CustomizableOutDir>true</CustomizableOutDir>
     <CustomizablePublishDir>true</CustomizablePublishDir>
@@ -11,13 +12,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectToBuild Include="../src/NLog.AirBrake.sln">
-      <Properties>Configuration=$(Configuration);OutDir=$(BuildOutDir)</Properties>
+    <ProjectToBuild Include="../src/NLog.AirBrake.sln" Condition=" '$(TargetFrameworkVersion)' == 'v2.0' ">
+      <Properties>Configuration=$(Configuration);OutDir=$(BuildOutDir);</Properties>
+    </ProjectToBuild>
+    <ProjectToBuild Include="../src/NLog.AirBrake.sln" Condition=" '$(TargetFrameworkVersion)' == 'v4.0' ">
+      <Properties>Configuration=$(Configuration);OutDir=$(BuildOutDir);TargetFrameworkVersion=$(TargetFrameworkVersion)</Properties>
     </ProjectToBuild>
   </ItemGroup>
 
   <Target Name="Build">
     <MSBuild Projects="@(ProjectToBuild)" BuildInParallel="$(BuildInParallel)"
-      Properties="Configuration=$(Configuration)" />
+      Properties="Configuration=$(Configuration)" Targets="Clean;Build" />
   </Target>
 </Project>

--- a/build/default.ps1
+++ b/build/default.ps1
@@ -27,7 +27,9 @@ Task default -Depends Test, Package
 Task Compile -Depends Init,Clean {
   "Starting compilation process... "
 
+  #build .NET2 and .NET4 versions separately
   exec { msbuild build.proj }
+  exec { msbuild build.proj /p:TargetFrameworkVersion=v4.0 }
 }
 
 Task Package -Depends Compile, Test {
@@ -37,7 +39,7 @@ Task Package -Depends Compile, Test {
   Copy-Item $sourceNuspec -Destination $nuspecPath
 
   $nuspec = [Xml](Get-Content $nuspecPath)
-  $compiled = Join-Path $BuildOutDir 'NLog.AirBrake.dll'
+  $compiled = Join-Path $BuildOutDir 'v2.0\NLog.AirBrake.dll'
   $version = (Get-Command $compiled).FileVersionInfo.FileVersion
   $nuspec.package.metadata.version = $version
   $nuspec.Save($nuspecPath)

--- a/src/NLog.AirBrake.TestApp/NLog.AirBrake.TestApp.csproj
+++ b/src/NLog.AirBrake.TestApp/NLog.AirBrake.TestApp.csproj
@@ -38,15 +38,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.2.0.0.2000\lib\net20\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Program.cs" />
@@ -70,7 +64,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/NLog.AirBrake.TestApp/Program.cs
+++ b/src/NLog.AirBrake.TestApp/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace NLog.AirBrake.TestApp

--- a/src/NLog.AirBrake/AirBrakeTarget.cs
+++ b/src/NLog.AirBrake/AirBrakeTarget.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using NLog.Targets;
 using SharpBrake;

--- a/src/NLog.AirBrake/Extensions.cs
+++ b/src/NLog.AirBrake/Extensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Runtime.CompilerServices
+    //This bit of code lets our project compile under .NET 2.0
+{
+   class ExtensionAttribute : Attribute
+   {
+
+   }
+}
+
+namespace NLog.AirBrake
+{
+
+    public static class ExtensionHolder
+    {
+
+    }
+}
+
+

--- a/src/NLog.AirBrake/ISharpbrakeClient.cs
+++ b/src/NLog.AirBrake/ISharpbrakeClient.cs
@@ -1,7 +1,6 @@
 ﻿using SharpBrake.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace NLog.AirBrake

--- a/src/NLog.AirBrake/NLog.AirBrake.csproj
+++ b/src/NLog.AirBrake/NLog.AirBrake.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog.AirBrake</RootNamespace>
     <AssemblyName>NLog.AirBrake</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -40,17 +40,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net35\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.2.0.0.2000\lib\net20\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
+    <Reference Include="System.configuration" />
     <Reference Include="System.Web" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
+    <Reference Include="System.XML" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="$(CroMagVersion)\SharedAssemblyInfo.cs">
@@ -60,6 +55,7 @@
       <DependentUpon>CroMagVersion.tt</DependentUpon>
     </Compile>
     <Compile Include="AirBrakeTarget.cs" />
+    <Compile Include="Extensions.cs" />
     <Compile Include="ISharpbrakeClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SharpbrakeClient.cs" />

--- a/src/NLog.AirBrake/NLog.AirBrake.csproj
+++ b/src/NLog.AirBrake/NLog.AirBrake.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NLog.AirBrake</RootNamespace>
     <AssemblyName>NLog.AirBrake</AssemblyName>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion Condition=" '$(TargetFrameworkVersion)' == '' ">v2.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
@@ -21,7 +21,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\$(TargetFrameworkVersion)\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -31,7 +31,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Release\$(TargetFrameworkVersion)\</OutputPath>
     <DefineConstants>TRACE;CROMAG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -95,11 +95,9 @@
   <Target Name="CroMagVersion" Condition="$(DefineConstants.Contains('CROMAG'))" BeforeTargets="CoreCompile">
     <Exec Command="$(CroMagVersion)\TextTransform.exe -o=&quot;$(CroMagVersion)\SharedAssemblyInfo.cs&quot; -a=&quot;Configuration!$(Configuration) &quot; -a=&quot;SolutionDir!$(SolutionDir) &quot; &quot;$(CroMagVersion)\CroMagVersion.tt&quot;" WorkingDirectory="$(MSBuildThisFileDirectory)" CustomErrorRegularExpression=".*: ERROR .*" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+    -->
 </Project>

--- a/src/NLog.AirBrake/SharpBrake/AirbrakeConfiguration.cs
+++ b/src/NLog.AirBrake/SharpBrake/AirbrakeConfiguration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Configuration;
-using System.Linq;
 using System.Web;
 
 namespace SharpBrake
@@ -27,7 +26,7 @@ namespace SharpBrake
             string[] values = ConfigurationManager.AppSettings.GetValues("Airbrake.AppVersion");
             
             if (values != null)
-                AppVersion = values.FirstOrDefault();
+                AppVersion = values[0];
         }
 
 

--- a/src/NLog.AirBrake/SharpBrake/AirbrakeResponse.cs
+++ b/src/NLog.AirBrake/SharpBrake/AirbrakeResponse.cs
@@ -1,12 +1,12 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Xml;
 
 //using Common.Logging;
 
 using SharpBrake.Serialization;
+using System.Collections.Generic;
 
 namespace SharpBrake
 {
@@ -155,7 +155,7 @@ namespace SharpBrake
                     switch (reader.LocalName)
                     {
                         case "errors":
-                            this.errors = reader.BuildErrors().ToArray();
+                            this.errors = new List<AirbrakeResponseError>(reader.BuildErrors()).ToArray();
                             break;
 
                         case "notice":

--- a/src/NLog.AirBrake/SharpBrake/Extensions.cs
+++ b/src/NLog.AirBrake/SharpBrake/Extensions.cs
@@ -11,6 +11,8 @@ namespace SharpBrake
     /// </summary>
     public static class Extensions
     {
+        //.Net 2.0 is missing Func, so we define our own here for the TryGet method.
+        public delegate TResult Func<in T1, out TResult>(T1 arg1);
         /// <summary>
         /// Sends the <paramref name="exception"/> to Airbrake.
         /// </summary>

--- a/src/NLog.AirBrake/SharpBrake/Serialization/AirbrakeRequest.cs
+++ b/src/NLog.AirBrake/SharpBrake/Serialization/AirbrakeRequest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Xml.Serialization;
 
 namespace SharpBrake.Serialization
@@ -67,7 +66,7 @@ namespace SharpBrake.Serialization
         [XmlArrayItem("var")]
         public AirbrakeVar[] CgiData
         {
-            get { return this.cgiData != null && this.cgiData.Any() ? this.cgiData : null; }
+            get { return this.cgiData != null && this.cgiData.Length > 0 ? this.cgiData : null; }
             set { this.cgiData = value; }
         }
 
@@ -90,7 +89,7 @@ namespace SharpBrake.Serialization
         [XmlArrayItem("var")]
         public AirbrakeVar[] Params
         {
-            get { return this.parameters != null && this.parameters.Any() ? this.parameters : null; }
+            get { return this.parameters != null && this.parameters.Length > 0 ? this.parameters : null; }
             set { this.parameters = value; }
         }
 
@@ -104,7 +103,7 @@ namespace SharpBrake.Serialization
         [XmlArrayItem("var")]
         public AirbrakeVar[] Session
         {
-            get { return this.session != null && this.session.Any() ? this.session : null; }
+            get { return this.session != null && this.session.Length > 0 ? this.session : null; }
             set { this.session = value; }
         }
 

--- a/src/NLog.AirBrake/SharpbrakeClient.cs
+++ b/src/NLog.AirBrake/SharpbrakeClient.cs
@@ -2,7 +2,6 @@
 using SharpBrake.Serialization;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace NLog.AirBrake

--- a/src/NLog.AirBrake/packages.config
+++ b/src/NLog.AirBrake/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CroMagVersion" version="0.3.4.0" targetFramework="net40" />
-  <package id="NLog" version="2.0.0.2000" targetFramework="net35" />
+  <package id="NLog" version="2.0.0.2000" targetFramework="net20" />
 </packages>

--- a/src/version.props
+++ b/src/version.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <VersioningScheme>
 	<MajorVersion>0</MajorVersion>
-	<MinorVersion>3</MinorVersion>
+	<MinorVersion>4</MinorVersion>
 	<VersionCompany>East Point Systems</VersionCompany>
 	<VersionCompanyUrl>http://github.com/EastPoint/NLog.AirBrake/</VersionCompanyUrl>
 	<!-- Typically this value will be supplied by a build server like Jenkins -->

--- a/tests/NLog.AirBrake.Tests/AirBrakeTargetTest.cs
+++ b/tests/NLog.AirBrake.Tests/AirBrakeTargetTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Xunit;
 using FakeItEasy;

--- a/tests/NLog.AirBrake.Tests/NLog.AirBrake.Tests.csproj
+++ b/tests/NLog.AirBrake.Tests/NLog.AirBrake.Tests.csproj
@@ -15,6 +15,11 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <TargetFrameworkProfile />
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>3.5</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -44,12 +49,6 @@
       <HintPath>..\..\src\packages\NLog.2.0.0.2000\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
     <Reference Include="xunit">
       <HintPath>..\..\src\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
     </Reference>
@@ -78,11 +77,9 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
   <Target Name="AfterBuild">
   </Target>
-  -->
+    -->
 </Project>


### PR DESCRIPTION
Removed linq and .net 3.5 required items. Added a couple tricks to get it to run under 2.0. Passes Xunit tests.
