### PR TITLE
Remove nlog.config dependency from nuget specification.

### DIFF
--- a/build/NLog.AirBrake.nuspec
+++ b/build/NLog.AirBrake.nuspec
@@ -21,7 +21,6 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="NLog" />
-      <dependency id="NLog.Config" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
The nlog.config dependency was introduced by mistake. Removing
to clean up the nuget package.
