### PR TITLE
IIS7 Error Fix - Request is not available in this context.

### DIFF
--- a/src/NLog.AirBrake/SharpBrake/AirbrakeConfiguration.cs
+++ b/src/NLog.AirBrake/SharpBrake/AirbrakeConfiguration.cs
@@ -19,9 +19,7 @@ namespace SharpBrake
             ServerUri = ConfigurationManager.AppSettings["Airbrake.ServerUri"]
                         ?? "https://api.airbrake.io/notifier_api/v2/notices";
 
-            ProjectRoot = HttpContext.Current != null
-                              ? HttpContext.Current.Request.ApplicationPath
-                              : Environment.CurrentDirectory;
+            ProjectRoot = HttpRuntime.AppDomainAppVirtualPath ?? Environment.CurrentDirectory;
 
             string[] values = ConfigurationManager.AppSettings.GetValues("Airbrake.AppVersion");
             


### PR DESCRIPTION
-In iis7 integrated mode, the request context is unavailable during
the application_start event. Due to this, we use the
HttpRuntime.AppDomainAppVirtualPath instead.
