### PR TITLE
Fixed: Negative line numbers in stack traces cause rejection from AirBrake endpoint

### DIFF
--- a/src/NLog.AirBrake/AirBrakeTarget.cs
+++ b/src/NLog.AirBrake/AirBrakeTarget.cs
@@ -72,9 +72,21 @@ namespace NLog.AirBrake
 
             int lineNumber = frame.GetFileLineNumber();
             lines.Add(new AirbrakeTraceLine("---- INNER EXCEPTION ----", 0));
+
             if (lineNumber == 0)
             {
                 lineNumber = frame.GetILOffset();
+            }
+
+            if (lineNumber == -1)
+            {
+                lineNumber = frame.GetNativeOffset();
+            }
+
+            // AirBrake doesn't allow for negative line numbers which can happen with lambdas
+            if (lineNumber < 0)
+            {
+                lineNumber = 0;
             }
 
             string file = frame.GetFileName();

--- a/src/NLog.AirBrake/SharpBrake/AirbrakeNoticeBuilder.cs
+++ b/src/NLog.AirBrake/SharpBrake/AirbrakeNoticeBuilder.cs
@@ -275,6 +275,17 @@ namespace SharpBrake
                     lineNumber = frame.GetILOffset();
                 }
 
+                if (lineNumber == -1)
+                {
+                    lineNumber = frame.GetNativeOffset();
+                }
+
+                // AirBrake doesn't allow for negative line numbers which can happen with lambdas
+                if (lineNumber < 0)
+                {
+                    lineNumber = 0;
+                }
+
                 string file = frame.GetFileName();
 
                 if (String.IsNullOrEmpty(file))


### PR DESCRIPTION
Protect against negative line numbers. Some (all?) AirBrake endpoins reject negative line numbers. These happen with Lambdas. In those cases, use the 'Native Offset' (as the .NET stack trace printer does)
