### PR TITLE
Update NLog version from 2.0.0.2000 to 2.0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ information can be found [here][net-encrypt]
 
 ## Release Notes
 
+#### 0.6
+* Updated NLog versions from 2.0.0.2000 to 2.0.1.2
+
+
+
 #### 0.5
 * Added support for using target without exceptions
 

--- a/src/NLog.AirBrake.TestApp/NLog.AirBrake.TestApp.csproj
+++ b/src/NLog.AirBrake.TestApp/NLog.AirBrake.TestApp.csproj
@@ -37,8 +37,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net20\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=2.0.1.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\NLog.2.0.1.2\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
   </ItemGroup>

--- a/src/NLog.AirBrake.TestApp/packages.config
+++ b/src/NLog.AirBrake.TestApp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="2.0.0.2000" targetFramework="net35" />
-  <package id="NLog.Config" version="2.0.0.2000" targetFramework="net35" />
+  <package id="NLog" version="2.0.1.2" targetFramework="net35" />
+  <package id="NLog.Config" version="2.0.1.2" targetFramework="net35" />
 </packages>

--- a/src/NLog.AirBrake/NLog.AirBrake.csproj
+++ b/src/NLog.AirBrake/NLog.AirBrake.csproj
@@ -40,10 +40,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' == 'v2.0'">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net20\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.2.0.1.2\lib\net20\NLog.dll</HintPath>
     </Reference>
     <Reference Include="NLog" Condition="'$(TargetFrameworkVersion)' == 'v4.0'">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
+      <HintPath>..\packages\NLog.2.0.1.2\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" Condition="'$(TargetFrameworkVersion)' == 'v4.0'" />

--- a/src/NLog.AirBrake/packages.config
+++ b/src/NLog.AirBrake/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CroMagVersion" version="0.3.5.0" targetFramework="net40" />
-  <package id="NLog" version="2.0.0.2000" targetFramework="net20" />
+  <package id="NLog" version="2.0.1.2" targetFramework="net20" />
 </packages>

--- a/src/version.props
+++ b/src/version.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <VersioningScheme>
 	<MajorVersion>0</MajorVersion>
-	<MinorVersion>5</MinorVersion>
+	<MinorVersion>6</MinorVersion>
 	<VersionCompany>East Point Systems</VersionCompany>
 	<VersionCompanyUrl>http://github.com/EastPoint/NLog.AirBrake/</VersionCompanyUrl>
 	<!-- Typically this value will be supplied by a build server like Jenkins -->

--- a/tests/NLog.AirBrake.Tests/NLog.AirBrake.Tests.csproj
+++ b/tests/NLog.AirBrake.Tests/NLog.AirBrake.Tests.csproj
@@ -45,8 +45,9 @@
     <Reference Include="FakeItEasy">
       <HintPath>..\..\src\packages\FakeItEasy.1.7.4626.65\lib\NET35\FakeItEasy.dll</HintPath>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\..\src\packages\NLog.2.0.0.2000\lib\net35\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=2.0.1.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\src\packages\NLog.2.0.1.2\lib\net35\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="xunit">

--- a/tests/NLog.AirBrake.Tests/packages.config
+++ b/tests/NLog.AirBrake.Tests/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Castle.Core" version="3.1.0" targetFramework="net35" />
   <package id="FakeItEasy" version="1.7.4626.65" targetFramework="net35" />
-  <package id="NLog" version="2.0.0.2000" targetFramework="net35" />
+  <package id="NLog" version="2.0.1.2" targetFramework="net35" />
   <package id="xunit" version="1.9.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
NLog's new stable version is 2.0.1.2. I updated references to reflect this new version and bumped up the minor version number as well.
