### PR TITLE
Fixed the failing test for GetBackTraceLines

### DIFF
--- a/tests/NLog.AirBrake.Tests/AirBrakeTargetTest.cs
+++ b/tests/NLog.AirBrake.Tests/AirBrakeTargetTest.cs
@@ -57,7 +57,8 @@ namespace NLog.AirBrake.Tests
             {
                 traceLines = target.GetBackTraceLines(ex, 1);
             }
-            Assert.True(traceLines.Count == 12);
+
+            Assert.Equal(10, traceLines.Count);
         }
         
     }

--- a/tests/NLog.AirBrake.Tests/InnerExceptionTestHelper.cs
+++ b/tests/NLog.AirBrake.Tests/InnerExceptionTestHelper.cs
@@ -7,16 +7,11 @@ namespace NLog.AirBrake.Tests
 {
     public class InnerExceptionTestHelper
     {
-        public void ThrowException1()
-        {
-            throw new Exception("Ex1");
-        }
-
         public void ThrowException()
         {
             try
             {
-                ThrowException1();
+                throw new Exception("Ex1");
             }
             catch (Exception e)
             {
@@ -35,7 +30,5 @@ namespace NLog.AirBrake.Tests
         {
             throw new Exception("Ex2", e);
         }
-
-
     }
 }


### PR DESCRIPTION
The test was failing because the number of BackTrace lines was different. It was passing when run from inside of the Visual Studio test runner, but failed when being run inside the build script. The stack traces differed by the Visual Studio version having the stacktrace point to the line in the `ThrowException1` method. Once that method was removed, they both had 10 lines.
